### PR TITLE
Change image source in _output.yml

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -14,7 +14,7 @@ bookdown::gitbook:
       after: |
        <p style="text-align:center;"> <a href="https://github.com/jhudsl/OTTR_Template" target="blank" > This content was published with</a> <a href="https://bookdown.org/" target="blank"> bookdown by: </a> </p>
        <p style="text-align:center;"> <a href="https://hutchdatascience.org/"> The Fred Hutch Data Science Lab </a></p>
-       <a href="https://hutchdatascience.org/" target="_blank"><img src="https://raw.githubusercontent.com/jhudsl/OTTR_Template/main/style-sets/fhdasl/copy_to_assets/big-dasl-stacked.png" style="width: 80%; padding-left: 34px; padding-top: 8px;"</a>
+       <a href="https://hutchdatascience.org/" target="_blank"><img src="https://avatars.githubusercontent.com/u/108835162?s=200&v=4" style="width: 80%; padding-left: 34px; padding-top: 8px;"</a>
        <p style="text-align:center; font-size: 12px;"> <a href="https://github.com/rstudio4edu/rstudio4edu-book/"> Style adapted from: rstudio4edu-book </a> <a href ="https://creativecommons.org/licenses/by/2.0/"> (CC-BY 2.0) </a></p>
        <p style="padding-left: 40px;"><div class="trapezoid" style = "padding-left: 40px;"><span><a href="https://docs.google.com/forms/d/e/1FAIpQLScrDVb_utm55pmb_SHx-RgELTEbCCWdLea0T3IzS0Oj00GE4w/viewform?usp=pp_url&entry.1565230805=AnVIL+Demos"> Click here to provide feedback</a> <img src="assets/itcr_arrow.png" style=" width: 10%" ></span></div></p>
        


### PR DESCRIPTION
Updated image source for the Fred Hutch Data Science Lab link, as I noticed it was missing. I can't preview this image or the other image I might use right now as GitHub is having issues.... something like this maybe: https://raw.githubusercontent.com/ottrproject/OTTR_Template/blob/main/style-sets/fhdasl/copy_to_assets/big-dasl-stacked.png

